### PR TITLE
Feature/terraform uses commit hash tagged containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
 
   print_output_from_get_docker_image_tags_job:
     runs-on: ubuntu-latest
+    needs: [get_docker_image_tags]
     steps:
       - run: echo ${{needs.get_docker_image_tags.outputs.webapp_hash}}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       webapp_commit_hash: ${{ steps.get_webapp_commit_hash.outputs.webapp_commit_hash }}
+      service_commit_hash: ${{ steps.get_service_commit_hash.outputs.service_commit_hash }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -28,12 +29,19 @@ jobs:
       - id: get_webapp_commit_hash
         name: Get commit hash from Webapp repo
         run: echo "::set-output name=webapp_commit_hash::$(git rev-parse HEAD)"
+      - uses: actions/checkout@v2
+        with:
+          repository: 'madetech/mca-beacons-service'
+      - id: get_service_commit_hash
+        name: Get commit hash from Service repo
+        run: echo "::set-output name=service_commit_hash::$(git rev-parse HEAD)"
 
   print_output_from_get_docker_image_tags_job:
     runs-on: ubuntu-latest
     needs: [get_docker_image_tags]
     steps:
       - run: echo ${{needs.get_docker_image_tags.outputs.webapp_commit_hash}}
+      - run: echo ${{needs.get_docker_image_tags.outputs.service_commit_hash}}
 
   terraform_deploy:
     needs: [terraform_lint]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Terraform Lint
         run: terraform fmt --recursive --check
 
-  terraform_get_docker_image_tags:
+  get_docker_image_tags:
     name: Get Docker image tags
     runs-on: ubuntu-latest
     steps:
@@ -25,6 +25,11 @@ jobs:
           repository: 'madetech/mca-beacons-webapp'
       - name: get_commit_hash
         run: git rev-parse HEAD
+
+  print_output_from_get_docker_image_tags_job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{needs.get_docker_image_tags.outputs.webapp_hash}}
 
   terraform_deploy:
     needs: [terraform_lint]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,15 +36,8 @@ jobs:
         name: Get commit hash from Service repo
         run: echo "::set-output name=service_commit_hash::$(git rev-parse HEAD)"
 
-  print_output_from_get_docker_image_tags_job:
-    runs-on: ubuntu-latest
-    needs: [get_docker_image_tags]
-    steps:
-      - run: echo ${{needs.get_docker_image_tags.outputs.webapp_commit_hash}}
-      - run: echo ${{needs.get_docker_image_tags.outputs.service_commit_hash}}
-
   terraform_deploy:
-    needs: [terraform_lint]
+    needs: [terraform_lint, get_docker_image_tags]
     if: github.ref == 'refs/heads/main'
     name: Terraform Deploy
     runs-on: ubuntu-latest
@@ -54,7 +47,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
@@ -63,4 +55,7 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
       - name: Terraform Deploy
-        run: terraform apply -auto-approve
+        env:
+          SERVICE_IMAGE_TAG: ${{needs.get_docker_image_tags.outputs.service_commit_hash}}
+          WEBAPP_IMAGE_TAG: ${{needs.get_docker_image_tags.outputs.webapp_commit_hash}}
+        run: terraform apply -auto-approve -var 'service_image_tag=${SERVICE_IMAGE_TAG}' -var 'webapp_image_tag=${WEBAPP_IMAGE_TAG}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,18 +19,21 @@ jobs:
   get_docker_image_tags:
     name: Get Docker image tags
     runs-on: ubuntu-latest
+    outputs:
+      webapp_commit_hash: ${{ steps.get_webapp_commit_hash.outputs.webapp_commit_hash }}
     steps:
       - uses: actions/checkout@v2
         with:
           repository: 'madetech/mca-beacons-webapp'
-      - name: get_commit_hash
-        run: git rev-parse HEAD
+      - id: get_webapp_commit_hash
+        name: Get commit hash from Webapp repo
+        run: echo "::set-output name=webapp_commit_hash::$(git rev-parse HEAD)"
 
   print_output_from_get_docker_image_tags_job:
     runs-on: ubuntu-latest
     needs: [get_docker_image_tags]
     steps:
-      - run: echo ${{needs.get_docker_image_tags.outputs.webapp_hash}}
+      - run: echo ${{needs.get_docker_image_tags.outputs.webapp_commit_hash}}
 
   terraform_deploy:
     needs: [terraform_lint]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,16 @@ jobs:
       - name: Terraform Lint
         run: terraform fmt --recursive --check
 
+  terraform_get_docker_image_tags:
+    name: Get Docker image tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'madetech/mca-beacons-webapp'
+      - name: get_commit_hash
+        run: git rev-parse HEAD
+
   terraform_deploy:
     needs: [terraform_lint]
     if: github.ref == 'refs/heads/main'

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -30,12 +30,11 @@ resource "aws_ecs_task_definition" "webapp" {
 }
 
 resource "aws_ecs_service" "webapp" {
-  name                 = "beacons-webapp"
-  cluster              = aws_ecs_cluster.main.id
-  task_definition      = aws_ecs_task_definition.webapp.arn
-  desired_count        = var.webapp_count
-  launch_type          = "FARGATE"
-  force_new_deployment = true
+  name            = "beacons-webapp"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.webapp.arn
+  desired_count   = var.webapp_count
+  launch_type     = "FARGATE"
 
   network_configuration {
     security_groups = [aws_security_group.ecs_tasks.id]
@@ -79,12 +78,11 @@ resource "aws_ecs_task_definition" "service" {
 }
 
 resource "aws_ecs_service" "service" {
-  name                 = "beacons-service"
-  cluster              = aws_ecs_cluster.main.id
-  task_definition      = aws_ecs_task_definition.service.arn
-  desired_count        = var.service_count
-  launch_type          = "FARGATE"
-  force_new_deployment = true
+  name            = "beacons-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.service.arn
+  desired_count   = var.service_count
+  launch_type     = "FARGATE"
 
   network_configuration {
     security_groups = [aws_security_group.ecs_tasks.id]

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_task_definition" "webapp" {
   memory                   = var.webapp_fargate_memory
   container_definitions = jsonencode([{
     "name" : "beacons-webapp",
-    "image" : var.webapp_image,
+    "image" : "${var.webapp_image}:${var.webapp_image_tag}",
     "portMappings" : [
       {
         "containerPort" : var.webapp_port
@@ -60,7 +60,7 @@ resource "aws_ecs_task_definition" "service" {
   memory                   = var.service_fargate_memory
   container_definitions = jsonencode([{
     "name" : "beacons-service",
-    "image" : var.service_image,
+    "image" : "${var.service_image}:${var.service_image_tag}",
     "portMappings" : [
       {
         "containerPort" : var.service_port

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,7 +26,11 @@ variable "app_name" {
 variable "webapp_image" {
   type        = string
   description = "Docker image to run in the ECS cluster for the Beacons Webapp"
-  default     = "261219435789.dkr.ecr.eu-west-2.amazonaws.com/mca-beacons-webapp:main"
+  default     = "261219435789.dkr.ecr.eu-west-2.amazonaws.com/mca-beacons-webapp"
+}
+variable "webapp_image_tag" {
+  type = string
+  description = "Hash of the relevant commit to the mca-beacons-webapp repo"
 }
 variable "webapp_port" {
   type        = number
@@ -53,11 +57,14 @@ variable "webapp_fargate_memory" {
   description = "Fargate instance memory to provision (in MiB) for the Beacons Webapp"
   default     = 2048
 }
-# TODO: get updated task docker image from registry of choice. 
 variable "service_image" {
   type        = string
   description = "Docker image to run in the ECS cluster"
-  default     = "261219435789.dkr.ecr.eu-west-2.amazonaws.com/mca-beacons-service:main"
+  default     = "261219435789.dkr.ecr.eu-west-2.amazonaws.com/mca-beacons-service"
+}
+variable "service_image_tag" {
+  type = string
+  description = "Hash of the relevant commit to the mca-beacons-service repo"
 }
 variable "service_port" {
   type        = number

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,7 +29,7 @@ variable "webapp_image" {
   default     = "261219435789.dkr.ecr.eu-west-2.amazonaws.com/mca-beacons-webapp"
 }
 variable "webapp_image_tag" {
-  type = string
+  type        = string
   description = "Hash of the relevant commit to the mca-beacons-webapp repo"
 }
 variable "webapp_port" {
@@ -63,7 +63,7 @@ variable "service_image" {
   default     = "261219435789.dkr.ecr.eu-west-2.amazonaws.com/mca-beacons-service"
 }
 variable "service_image_tag" {
-  type = string
+  type        = string
   description = "Hash of the relevant commit to the mca-beacons-service repo"
 }
 variable "service_port" {


### PR DESCRIPTION
- Opening this PR to test GitHub Actions and Terraform CI/CD pipeline passes commit hash through. This is so ECS images are tagged with the commit message, so that Terraform knows something has changed, so that Terraform updates the infrastructure.